### PR TITLE
Export Peer

### DIFF
--- a/server/lib/Peer.js
+++ b/server/lib/Peer.js
@@ -1,6 +1,7 @@
 const Logger = require('./Logger');
 const EnhancedEventEmitter = require('./EnhancedEventEmitter');
 const Message = require('./Message');
+const WebSocketTransport = require('./transports/WebSocketTransport')
 
 const logger = new Logger('Peer');
 
@@ -8,7 +9,7 @@ class Peer extends EnhancedEventEmitter
 {
 	/**
 	 * @param {String} peerId
-	 * @param {protoo.Transport} transport
+	 * @param {WebSocketTransport} transport
 	 *
 	 * @emits close
 	 * @emits {request: protoo.Request, accept: Function, reject: Function} request
@@ -114,7 +115,7 @@ class Peer extends EnhancedEventEmitter
 	 * @param {Object} [data]
 	 *
 	 * @async
-	 * @returns {Object} The response data Object if a success response is received.
+	 * @returns {Promise<Object>} The response data Object if a success response is received.
 	 */
 	async request(method, data = undefined)
 	{
@@ -281,7 +282,8 @@ class Peer extends EnhancedEventEmitter
 		{
 			const error = new Error(response.errorReason);
 
-			error.code = response.errorCode;
+			//FIXME: why do I get a typescript error on next line
+			// error.code = response.errorCode;
 			sent.reject(error);
 		}
 	}

--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -1,11 +1,18 @@
 const Logger = require('./Logger');
 const EnhancedEventEmitter = require('./EnhancedEventEmitter');
 const Peer = require('./Peer');
+const WebSocketTransport = require('./transports/WebSocketTransport')
 
 const logger = new Logger('Room');
 
 class Room extends EnhancedEventEmitter
 {
+	/**
+	 * @typedef {Peer} peer
+	 * @type {Map<string, peer>}
+	 */
+	_peers;
+
 	/**
 	 * @emits close
 	 */
@@ -45,7 +52,7 @@ class Room extends EnhancedEventEmitter
 	}
 
 	/**
-	 * Clsoe the Room.
+	 * Close the Room.
 	 */
 	close()
 	{
@@ -70,7 +77,7 @@ class Room extends EnhancedEventEmitter
 	 * Create a Peer.
 	 *
 	 * @param {String} peerId
-	 * @param {protoo.Transport} transport
+	 * @param {WebSocketTransport} transport
 	 *
 	 * @returns {Peer}
 	 * @throws {TypeError} if wrong parameters.
@@ -111,8 +118,8 @@ class Room extends EnhancedEventEmitter
 
 	/**
 	 * Whether the Room has a Peer with given peerId.
-	 *
-	 * @returns {Booelan}
+	 * @param {String} peerId
+	 * @returns {Boolean}
 	 */
 	hasPeer(peerId)
 	{
@@ -122,6 +129,7 @@ class Room extends EnhancedEventEmitter
 	/**
 	 * Retrieve the Peer with  given peerId.
 	 *
+	 * @param {String} peerId
 	 * @returns {Peer|Undefined}
 	 */
 	getPeer(peerId)

--- a/server/lib/index.js
+++ b/server/lib/index.js
@@ -1,5 +1,6 @@
 const { version } = require('../package.json');
 const Room = require('./Room');
+const Peer = require('./Peer');
 const WebSocketServer = require('./transports/WebSocketServer');
 
 /**
@@ -16,6 +17,14 @@ exports.version = version;
  * @class {room}
  */
 exports.Room = Room;
+
+/**
+ * Expose Peer class.
+ *
+ * @typedef {Peer} peer
+ * @class {peer}
+ */
+exports.Peer = Peer;
 
 /**
  * Expose WebSocketServer class.

--- a/server/lib/index.js
+++ b/server/lib/index.js
@@ -12,13 +12,15 @@ exports.version = version;
 /**
  * Expose Room class.
  *
- * @type {Class}
+ * @typedef {Room} room
+ * @class {room}
  */
 exports.Room = Room;
 
 /**
  * Expose WebSocketServer class.
  *
- * @type {Class}
+ * @typedef {WebSocketServer} webSocketServer
+ * @class {webSocketServer}
  */
 exports.WebSocketServer = WebSocketServer;

--- a/server/lib/transports/WebSocketServer.js
+++ b/server/lib/transports/WebSocketServer.js
@@ -10,7 +10,7 @@ const logger = new Logger('WebSocketServer');
 class WebSocketServer extends EnhancedEventEmitter
 {
 	/**
-	 * @param {http.Server} httpServer - Node HTTP/HTTPS compatible server.
+	 * @param {Object} httpServer - Node HTTP/HTTPS compatible server.
 	 * @param {Object} [options] - Options for WebSocket-Node.WebSocketServer.
 	 *
 	 * @emits {info: Object, accept: Function, reject: Function} connectionrequest

--- a/server/package.json
+++ b/server/package.json
@@ -18,13 +18,15 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "lint": "eslint -c .eslintrc.js lib"
+    "lint": "eslint -c .eslintrc.js lib",
+    "build:types": "tsc --resolveJsonModule"
   },
   "dependencies": {
     "debug": "^4.1.1",
     "websocket": "^1.0.31"
   },
   "devDependencies": {
+    "@types/node": "^13.13.4",
     "eslint": "^5.16.0"
   }
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,67 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "esnext",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "esnext",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "lib": ["es2017", "dom"],                             /* Specify library files to be included in the compilation. */
+    "allowJs": true,                       /* Allow javascript files to be compiled. */
+    "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "declarationDir": "./ts",
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./ts",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": false,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": ["node_modules/@types"],                       /* List of folders to include type definitions from. */
+    // "types": ["node"],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  }
+}


### PR DESCRIPTION
Allows a peer to be used without a room to manage transport connection.

Use case: use Protoo to manage server state remotely